### PR TITLE
fix(installer): treat macOS tty/cu serial pair as one R1 preloader

### DIFF
--- a/installer/TROUBLESHOOTING.md
+++ b/installer/TROUBLESHOOTING.md
@@ -19,6 +19,36 @@ Keep the complete code and message when reporting a problem.
 Never use an arbitrary internet command or manually choose a partition to work
 around an installer failure.
 
+## What the terminal shows while the installer works
+
+The installer prints a line for each major action, so you can tell progress is
+moving. A quiet terminal does not mean it stopped; a few short waits are
+intentionally silent and last for a stated number of seconds.
+
+- `Verifying 1/12: images/...` through `12/12` appears once per image as the
+  package checks its recorded images against the signed release. No R1 is
+  touched yet.
+- The `JackRabbit R1 setup ... Step N of 4` screens are preparation prompts.
+  Nothing is written while you read them.
+- `Waiting up to 60 seconds for the R1. Connect it now.` is the connect window.
+  It stays quiet while it watches for the preloader, FASTBOOT, or fastbootd;
+  that silence is normal and lasts at most 60 seconds. If the terminal has not
+  advanced past it after a full 60 seconds, see the
+  `JR-CLI-FASTBOOT-ENTRY-TIMEOUT` row below.
+- `FASTBOOT entry command sent. Waiting for the R1 FASTBOOT screen…` means the
+  powered-off preloader was found and the eight-byte entry command was sent.
+  Watch the R1 for its FASTBOOT screen.
+- `[N/22] ...` lines are the numbered write and verify steps. A blank R1 display
+  while `super` is written (`[10/22]`) is expected; keep the cable connected and
+  follow the terminal, not the device screen.
+- Around a reboot into fastbootd or bootloader FASTBOOT, the terminal can pause
+  silently for up to 90 seconds while it waits for the R1 to reconnect in the
+  requested mode (`JR-CLI-MODE-TIMEOUT` guards this). The R1 changing USB
+  identity during that pause is normal.
+
+If you are unsure whether a transfer is still active, start with the "First
+decide whether a transfer is still active" section above.
+
 ## Common situations
 
 ### The R1 already shows FASTBOOT or fastbootd
@@ -52,7 +82,9 @@ USB interfaces, so one working mode does not prove the next driver is installed.
 
 Close every browser flasher and Android tool that could own the R1, disconnect
 and reconnect the cable, and rerun `install.command`. macOS needs no packaged
-R1 driver.
+R1 driver. On macOS a single powered-off R1 in preloader mode briefly lists as
+both `/dev/cu.usbmodemN` and `/dev/tty.usbmodemN`; the installer treats these as
+one device, so a lone R1 is enough and this pair should not be taken as two R1s.
 
 ### An entry was typed incorrectly
 
@@ -75,7 +107,7 @@ the displayed phrase exactly.
 | `JR-CLI-USB-PERMISSION` | Linux denied access to an R1 USB identity. | Run `./install.sh`, allow the udev-rule setup, reconnect when prompted, and retry the same flow. |
 | `JR-CLI-FASTBOOT-ENTRY-TIMEOUT` | No supported R1 preloader, FASTBOOT, or fastbootd identity appeared within 60 seconds. | Confirm the R1 is powered off or already in a supported fastboot mode, use a data cable, connect exactly when prompted, and rerun. |
 | `JR-CLI-PRELOADER-ENUMERATE` | The host could not enumerate serial devices. | Close competing serial tools, check the OS driver/permission setup, reconnect, and rerun. |
-| `JR-CLI-PRELOADER-COUNT` | More than one exact R1 preloader appeared. | Disconnect all R1 devices except the intended one. |
+| `JR-CLI-PRELOADER-COUNT` | More than one distinct R1 preloader appeared. | Disconnect every R1 except the intended one. On macOS a lone R1 that briefly lists two `tty`/`cu` node names is one device and is handled; only a truly second R1 triggers this. |
 | `JR-CLI-PRELOADER-OPEN` | The exact R1 preloader port could not be opened. | Close Rabbit's flasher and serial tools; on Linux rerun `install.sh`; on Windows repair the packaged drivers. |
 | `JR-CLI-PRELOADER-WRITE` | The eight-byte R1 FASTBOOT-entry command could not be sent. | Reconnect the powered-off R1 with a reliable data cable and rerun the package. |
 | `JR-CLI-PRODUCT` | The connected fastboot device is not the reviewed R1 product. | Stop. Connect only the Rabbit R1 intended for installation. |

--- a/installer/cli/src/preloader.rs
+++ b/installer/cli/src/preloader.rs
@@ -50,14 +50,43 @@ pub fn try_enter() -> Result<bool, CommandError> {
 }
 
 fn select_exact(candidates: &[String]) -> Result<Option<&str>, CommandError> {
-    match candidates {
+    let distinct = dedupe_logical(candidates);
+    match distinct.as_slice() {
         [] => Ok(None),
         [only] => Ok(Some(only)),
         _ => Err(CommandError::new(
             "JR-CLI-PRELOADER-COUNT",
-            "more than one exact R1 preloader device appeared; disconnect every R1 and retry with one device",
+            format!(
+                "more than one exact R1 preloader device appeared ({}); disconnect every R1 and retry with one device",
+                distinct.len()
+            ),
         )),
     }
+}
+
+/// Collapse macOS `tty.*`/`cu.*` device-node pairs for the same physical serial
+/// line into a single logical device. A USB CDC preloader registers both
+/// `/dev/cu.usbmodemNNN` and `/dev/tty.usbmodemNNN`; they are one R1, not two.
+/// Truly distinct devices keep distinct names and still count separately.
+fn dedupe_logical<'a>(candidates: &'a [String]) -> Vec<&'a str> {
+    let mut distinct: Vec<&'a str> = Vec::new();
+    for candidate in candidates {
+        let key = logical_device_key(candidate);
+        if !distinct
+            .iter()
+            .any(|existing| logical_device_key(existing) == key)
+        {
+            distinct.push(candidate);
+        }
+    }
+    distinct
+}
+
+fn logical_device_key(path: &str) -> &str {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    name.strip_prefix("cu.")
+        .or_else(|| name.strip_prefix("tty."))
+        .unwrap_or(name)
 }
 
 #[cfg(test)]
@@ -74,5 +103,28 @@ mod tests {
         assert_eq!(select_exact(&[]).unwrap(), None);
         assert_eq!(select_exact(&["r1".into()]).unwrap(), Some("r1"));
         assert!(select_exact(&["one".into(), "two".into()]).is_err());
+    }
+
+    #[test]
+    fn macos_tty_cu_pair_is_one_logical_device() {
+        // Regression: a single R1 registers both /dev/cu.usbmodem31201 and
+        // /dev/tty.usbmodem31201 on macOS; the installer must treat them as one R1.
+        let candidates = [
+            "/dev/cu.usbmodem31201".to_string(),
+            "/dev/tty.usbmodem31201".to_string(),
+        ];
+        let result = select_exact(&candidates).unwrap();
+        assert_eq!(result, Some("/dev/cu.usbmodem31201"));
+    }
+
+    #[test]
+    fn two_distinct_devices_still_fail() {
+        // Two genuinely different R1s must still be rejected.
+        let candidates = [
+            "/dev/cu.usbmodem31201".to_string(),
+            "/dev/cu.usbmodem31202".to_string(),
+        ];
+        let error = select_exact(&candidates).unwrap_err();
+        assert_eq!(error.code(), "JR-CLI-PRELOADER-COUNT");
     }
 }


### PR DESCRIPTION
## Problem

On macOS, a single R1 in preloader mode registers two BSD device nodes for its
one physical USB serial line:

- /dev/cu.usbmodemN
- /dev/tty.usbmodemN

Both carry USB identity 0e8d:2000. The installer's select_exact counted the
pair as two separate R1s and aborted with JR-CLI-PRELOADER-COUNT ("more than
one exact R1 preloader device appeared") before ever sending the FASTBOOT
command, so macOS installs could not start.

## Fix

installer/cli/src/preloader.rs now collapses the tty.*/cu.* node pair for the
same physical line into one logical device before counting. A lone R1 is
detected and progressed; a truly distinct second R1 still fails as before.

## Validation

- cargo test --locked: 22/22 pass, including two new regression tests
  (tty/cu pair is one device; two distinct devices still fail).
- cargo fmt --check: clean.
- Verified end to end on real hardware: the fixed binary detected the
  powered-off R1, sent FASTBOOT, and completed a full 22-step install.

## Docs

Adds a "What the terminal shows while the installer works" section to
installer/TROUBLESHOOTING.md and clarifies the macOS tty/cu behavior in the
macOS entry and the JR-CLI-PRELOADER-COUNT row.