### PR TITLE
feat(telephony): add native telephony bridge + read-only get_phone_status tool

### DIFF
--- a/android/feature/telephony/build.gradle.kts
+++ b/android/feature/telephony/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins { id("com.android.library") }
+
+android {
+    namespace = "com.resonolabs.feature.telephony"
+    compileSdk = 36
+    defaultConfig { minSdk = 31 }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    testImplementation("junit:junit:4.13.2")
+}

--- a/android/feature/telephony/src/main/AndroidManifest.xml
+++ b/android/feature/telephony/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <application />
+</manifest>

--- a/android/feature/telephony/src/main/java/com/resonolabs/feature/telephony/AndroidTelephonyBridge.java
+++ b/android/feature/telephony/src/main/java/com/resonolabs/feature/telephony/AndroidTelephonyBridge.java
@@ -1,0 +1,87 @@
+package com.resonolabs.feature.telephony;
+
+import android.content.Context;
+import android.telephony.ServiceState;
+import android.telephony.SignalStrength;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
+
+/** {@link TelephonyBridge} backed by the Android telephony framework. */
+public final class AndroidTelephonyBridge implements TelephonyBridge {
+
+    private final TelephonyManager telephonyManager;
+    private final SubscriptionManager subscriptionManager;
+
+    public AndroidTelephonyBridge(Context context) {
+        this.telephonyManager = context.getSystemService(TelephonyManager.class);
+        this.subscriptionManager = context.getSystemService(SubscriptionManager.class);
+    }
+
+    @Override
+    public boolean simPresent() {
+        return telephonyManager.getSimState() != TelephonyManager.SIM_STATE_ABSENT;
+    }
+
+    @Override
+    public String simState() {
+        int state = telephonyManager.getSimState();
+        switch (state) {
+            case TelephonyManager.SIM_STATE_ABSENT: return "ABSENT";
+            case TelephonyManager.SIM_STATE_PIN_REQUIRED: return "PIN_REQUIRED";
+            case TelephonyManager.SIM_STATE_PUK_REQUIRED: return "PUK_REQUIRED";
+            case TelephonyManager.SIM_STATE_NETWORK_LOCKED: return "NETWORK_LOCKED";
+            case TelephonyManager.SIM_STATE_READY: return "READY";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @Override
+    public String carrierName() {
+        try {
+            return telephonyManager.getNetworkOperatorName();
+        } catch (SecurityException e) {
+            return "";
+        }
+    }
+
+    @Override
+    public String networkType() {
+        return networkTypeString(telephonyManager.getDataNetworkType());
+    }
+
+    @Override
+    public int signalLevel() {
+        SignalStrength strength = telephonyManager.getSignalStrength();
+        return strength == null ? 0 : strength.getLevel();
+    }
+
+    @Override
+    public boolean voiceRegistered() {
+        ServiceState state = telephonyManager.getServiceState();
+        return state != null && state.getState() == ServiceState.STATE_IN_SERVICE;
+    }
+
+    @Override
+    public String callState() {
+        int state = telephonyManager.getCallState();
+        switch (state) {
+            case TelephonyManager.CALL_STATE_IDLE: return "IDLE";
+            case TelephonyManager.CALL_STATE_RINGING: return "RINGING";
+            case TelephonyManager.CALL_STATE_OFFHOOK: return "OFFHOOK";
+            default: return "UNKNOWN";
+        }
+    }
+
+    private static String networkTypeString(int type) {
+        switch (type) {
+            case TelephonyManager.NETWORK_TYPE_LTE: return "LTE";
+            case TelephonyManager.NETWORK_TYPE_NR: return "NR";
+            case TelephonyManager.NETWORK_TYPE_UMTS: return "UMTS";
+            case TelephonyManager.NETWORK_TYPE_EDGE: return "EDGE";
+            case TelephonyManager.NETWORK_TYPE_GPRS: return "GPRS";
+            case TelephonyManager.NETWORK_TYPE_GSM: return "GSM";
+            case TelephonyManager.NETWORK_TYPE_CDMA: return "CDMA";
+            default: return TelephonyManager.getNetworkTypeName(type);
+        }
+    }
+}

--- a/android/feature/telephony/src/main/java/com/resonolabs/feature/telephony/TelephonyBridge.java
+++ b/android/feature/telephony/src/main/java/com/resonolabs/feature/telephony/TelephonyBridge.java
@@ -1,0 +1,12 @@
+package com.resonolabs.feature.telephony;
+
+/** Read-only native telephony surface exposed to the on-device agent runtime. */
+public interface TelephonyBridge {
+    boolean simPresent();
+    String simState();
+    String carrierName();
+    String networkType();
+    int signalLevel();
+    boolean voiceRegistered();
+    String callState();
+}

--- a/android/feature/telephony/src/test/java/com/resonolabs/feature/telephony/TelephonyBridgeContractTest.java
+++ b/android/feature/telephony/src/test/java/com/resonolabs/feature/telephony/TelephonyBridgeContractTest.java
@@ -1,0 +1,27 @@
+package com.resonolabs.feature.telephony;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TelephonyBridgeContractTest {
+    @Test
+    public void interface_matches_python_bridge_contract() {
+        // Signature lock: these names/types are the Python-side contract.
+        TelephonyBridge bridge = new TelephonyBridge() {
+            @Override public boolean simPresent() { return false; }
+            @Override public String simState() { return "ABSENT"; }
+            @Override public String carrierName() { return ""; }
+            @Override public String networkType() { return ""; }
+            @Override public int signalLevel() { return 0; }
+            @Override public boolean voiceRegistered() { return false; }
+            @Override public String callState() { return "IDLE"; }
+        };
+        assertNotNull(bridge.simState());
+        assertEquals("ABSENT", bridge.simState());
+        assertEquals("IDLE", bridge.callState());
+        assertTrue(!bridge.simPresent());
+    }
+}

--- a/android/runtime-host/build.gradle.kts
+++ b/android/runtime-host/build.gradle.kts
@@ -41,5 +41,6 @@ chaquopy {
 }
 
 dependencies {
+    implementation(project(":feature:telephony"))
     testImplementation("junit:junit:4.13.2")
 }

--- a/android/runtime-host/src/main/java/com/resonolabs/runtime/host/RuntimePythonHost.java
+++ b/android/runtime-host/src/main/java/com/resonolabs/runtime/host/RuntimePythonHost.java
@@ -13,12 +13,13 @@ final class RuntimePythonHost {
             String rootPath,
             String localApiToken,
             RuntimeCredentialBridge credentials,
-            Runnable restartRequest) {
+            Runnable restartRequest,
+            Object telephonyBridge) {
         if (running) return;
         if (!Python.isStarted()) Python.start(new AndroidPlatform(context));
         Python.getInstance()
                 .getModule("resono_runtime.entrypoint")
-                .callAttr("start", rootPath, localApiToken, credentials, restartRequest);
+                .callAttr("start", rootPath, localApiToken, credentials, restartRequest, telephonyBridge);
         running = true;
     }
 

--- a/android/runtime-host/src/main/java/com/resonolabs/runtime/host/RuntimeService.java
+++ b/android/runtime-host/src/main/java/com/resonolabs/runtime/host/RuntimeService.java
@@ -12,6 +12,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import com.resonolabs.feature.telephony.AndroidTelephonyBridge;
+
 import java.io.File;
 
 public final class RuntimeService extends Service {
@@ -75,7 +77,8 @@ public final class RuntimeService extends Service {
 
     private void startPython() {
         File root = new File(runtimeStorage.getFilesDir(), "runtime");
-        python.start(this, root.getAbsolutePath(), localApiToken, credentials, this::scheduleRuntimeRestart);
+        AndroidTelephonyBridge telephonyBridge = new AndroidTelephonyBridge(this);
+        python.start(this, root.getAbsolutePath(), localApiToken, credentials, this::scheduleRuntimeRestart, telephonyBridge);
     }
 
     private void scheduleRuntimeRestart() {

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -22,6 +22,7 @@ include(
     ":core:power",
     ":core:motor",
     ":feature:settings",
+    ":feature:telephony",
     ":feature:voice",
     ":feature:cards",
     ":feature:calendar",

--- a/runtime/pytest.ini
+++ b/runtime/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/runtime/requirements-dev.txt
+++ b/runtime/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Python runtime test dependencies. The runtime itself pins deps in the
+# Android Chaquopy build; this is the local dev/test mirror.
+pytest>=8
+jsonschema>=4
+httpx>=0.27
+openai-agents>=0.18
+openai>=1.40
+aiosqlite>=0.20
+pyyaml>=6

--- a/runtime/resono_runtime/application.py
+++ b/runtime/resono_runtime/application.py
@@ -30,6 +30,8 @@ from .storage.provider_catalog import ProviderCatalogRepository
 from .core.logging import runtime_logger
 from .tools import (DEVICE_STATUS_TOOL_SET, MEMORY_TOOL_SET, ToolCatalog,
                     register_device_status, register_memory_tools)
+from .telephony.access import TelephonyAccess
+from .tools.telephony import register_telephony_status
 from .skills import SkillActivation, AgentInstructionDocuments
 from .skills.lifecycle import SkillLifecycle
 from .api.skill_routes import SkillRoutes
@@ -89,6 +91,7 @@ class RuntimeApplication:
         config: RuntimeConfig,
         credential_bridge: object,
         restart_request: object | None = None,
+        telephony_bridge: object | None = None,
     ) -> None:
         self._config = config
         self._database = RuntimeDatabase(config.database_path)
@@ -138,6 +141,7 @@ class RuntimeApplication:
         self._tools.set_invocation_authorizer(self._voice_modes.allows)
         self._tools.set_invocation_observer(VoiceToolEvidenceRecorder(self._sessions))
         register_device_status(self._tools, self.health)
+        register_telephony_status(self._tools, TelephonyAccess(telephony_bridge))
         register_memory_tools(self._tools, MemoryToolPackage(
             lookup=self._memory_lookup_tool,
             memories=self._memories,

--- a/runtime/resono_runtime/entrypoint.py
+++ b/runtime/resono_runtime/entrypoint.py
@@ -16,6 +16,7 @@ def start(
     local_api_token: str,
     credential_bridge: object,
     restart_request: object | None = None,
+    telephony_bridge: object | None = None,
 ) -> None:
     global _application
     with _lock:
@@ -28,6 +29,7 @@ def start(
             config,
             credential_bridge=credential_bridge,
             restart_request=restart_request,
+            telephony_bridge=telephony_bridge,
         )
         application.start()
         _application = application

--- a/runtime/resono_runtime/telephony/__init__.py
+++ b/runtime/resono_runtime/telephony/__init__.py
@@ -1,0 +1,4 @@
+"""Native telephony access for the on-device agent runtime."""
+from .access import TelephonyAccess
+
+__all__ = ["TelephonyAccess"]

--- a/runtime/resono_runtime/telephony/access.py
+++ b/runtime/resono_runtime/telephony/access.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+
+def _as_bool(value: object, default: bool = False) -> bool:
+    return bool(value) if value is not None else default
+
+
+def _as_str(value: object, default: str = "") -> str:
+    return str(value) if value is not None else default
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class TelephonyAccess:
+    """Read-only facade over an injected native telephony bridge.
+
+    The bridge is the Java ``TelephonyBridge`` passed into
+    ``entrypoint.start`` (see the Android side of this slice). When it is
+    absent (or raises), every reader returns a safe disabled value so an
+    agent can never crash the runtime through this capability.
+    """
+
+    def __init__(self, bridge: object | None = None) -> None:
+        self._bridge = bridge
+
+    def enabled(self) -> bool:
+        return self._bridge is not None
+
+    def snapshot(self) -> dict[str, object]:
+        bridge = self._bridge
+        if bridge is None:
+            return {
+                "enabled": False,
+                "simPresent": False,
+                "simState": "unknown",
+                "carrierName": "",
+                "networkType": "",
+                "signalLevel": 0,
+                "voiceRegistered": False,
+                "callState": "",
+            }
+        try:
+            return {
+                "enabled": True,
+                "simPresent": _as_bool(bridge.simPresent()),
+                "simState": _as_str(bridge.simState(), "unknown"),
+                "carrierName": _as_str(bridge.carrierName()),
+                "networkType": _as_str(bridge.networkType()),
+                "signalLevel": _as_int(bridge.signalLevel()),
+                "voiceRegistered": _as_bool(bridge.voiceRegistered()),
+                "callState": _as_str(bridge.callState()),
+            }
+        except Exception:
+            return {
+                "enabled": True,
+                "simPresent": False,
+                "simState": "unknown",
+                "carrierName": "",
+                "networkType": "",
+                "signalLevel": 0,
+                "voiceRegistered": False,
+                "callState": "",
+            }

--- a/runtime/resono_runtime/tools/__init__.py
+++ b/runtime/resono_runtime/tools/__init__.py
@@ -2,6 +2,7 @@ from .builtins import (DEVICE_STATUS_TOOL_SET, MEMORY_TOOL_SET, register_device_
                        register_memory_lookup, register_memory_tools)
 from .catalog import ToolCatalog
 from .definitions import ToolDefinition, ToolInvocationContext, ToolInvocationResult
+from .telephony import register_telephony_status
 
 __all__ = [
     "DEVICE_STATUS_TOOL_SET",
@@ -13,4 +14,5 @@ __all__ = [
     "register_device_status",
     "register_memory_lookup",
     "register_memory_tools",
+    "register_telephony_status",
 ]

--- a/runtime/resono_runtime/tools/telephony.py
+++ b/runtime/resono_runtime/tools/telephony.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+from ..agents.audience import AudienceResource, AudienceResourceKind
+from ..telephony.access import TelephonyAccess
+from .catalog import ToolCatalog
+from .definitions import ToolDefinition, ToolInvocationResult
+
+TELEPHONY_STATUS_NAME = "get_phone_status"
+TELEPHONY_STATUS_TOOL_SET = AudienceResource(
+    AudienceResourceKind.DOMAIN_TOOL_SET, "telephony-status"
+)
+TELEPHONY_STATUS_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def register_telephony_status(catalog: ToolCatalog, access: TelephonyAccess) -> None:
+    def handle(_: dict[str, object]) -> ToolInvocationResult:
+        snapshot = access.snapshot()
+        return ToolInvocationResult(
+            text=json.dumps(snapshot, separators=(",", ":")),
+            structured_content=snapshot,
+        )
+
+    catalog.register(
+        ToolDefinition(
+            tool_id="telephony.status.v1",
+            name=TELEPHONY_STATUS_NAME,
+            description="Read current SIM, carrier, network, signal, and voice state from the R1 modem.",
+            input_schema=TELEPHONY_STATUS_SCHEMA,
+            handler=handle,
+            audience_resource=TELEPHONY_STATUS_TOOL_SET,
+        )
+    )

--- a/runtime/tests/test_get_phone_status_smoke.py
+++ b/runtime/tests/test_get_phone_status_smoke.py
@@ -1,0 +1,19 @@
+from resono_runtime.tools import ToolCatalog, register_telephony_status
+from resono_runtime.telephony.access import TelephonyAccess
+
+
+class FakeBridge:
+    def simPresent(self): return True
+    def simState(self): return "LOADED"
+    def carrierName(self): return "AT&T"
+    def networkType(self): return "LTE"
+    def signalLevel(self): return 3
+    def voiceRegistered(self): return True
+    def callState(self): return "IDLE"
+
+
+def test_registered_tool_returns_snapshot_end_to_end():
+    catalog = ToolCatalog()
+    register_telephony_status(catalog, TelephonyAccess(FakeBridge()))
+    result = catalog.invoke("get_phone_status", {})
+    assert result is not None and result.is_error is False

--- a/runtime/tests/test_telephony_access.py
+++ b/runtime/tests/test_telephony_access.py
@@ -1,0 +1,44 @@
+from resono_runtime.telephony.access import TelephonyAccess
+
+
+class FakeBridge:
+    def simPresent(self): return True
+    def simState(self): return "LOADED"
+    def carrierName(self): return "AT&T"
+    def networkType(self): return "LTE"
+    def signalLevel(self): return 2
+    def voiceRegistered(self): return True
+    def callState(self): return "IDLE"
+
+
+def test_snapshot_reads_bridge_primitives():
+    snap = TelephonyAccess(FakeBridge()).snapshot()
+    assert snap["enabled"] is True
+    assert snap["simPresent"] is True
+    assert snap["simState"] == "LOADED"
+    assert snap["carrierName"] == "AT&T"
+    assert snap["networkType"] == "LTE"
+    assert snap["signalLevel"] == 2
+    assert snap["voiceRegistered"] is True
+    assert snap["callState"] == "IDLE"
+
+
+def test_absent_bridge_is_disabled_with_safe_defaults():
+    snap = TelephonyAccess(None).snapshot()
+    assert snap["enabled"] is False
+    assert snap["simState"] == "unknown"
+    assert snap["carrierName"] == ""
+    assert snap["networkType"] == ""
+    assert snap["signalLevel"] == 0
+    assert snap["callState"] == ""
+
+
+class ThrowingBridge:
+    def simPresent(self):
+        raise RuntimeError("no radio")
+
+
+def test_bridge_failure_is_captured_not_raised():
+    snap = TelephonyAccess(ThrowingBridge()).snapshot()
+    assert snap["enabled"] is True
+    assert snap["simState"] == "unknown"

--- a/runtime/tests/test_telephony_tool.py
+++ b/runtime/tests/test_telephony_tool.py
@@ -1,0 +1,24 @@
+import json
+
+from resono_runtime.tools import ToolCatalog, register_telephony_status
+from resono_runtime.telephony.access import TelephonyAccess
+
+
+class FakeBridge:
+    def simPresent(self): return True
+    def simState(self): return "LOADED"
+    def carrierName(self): return "AT&T"
+    def networkType(self): return "LTE"
+    def signalLevel(self): return 2
+    def voiceRegistered(self): return True
+    def callState(self): return "IDLE"
+
+
+def test_get_phone_status_registers_and_returns_snapshot():
+    catalog = ToolCatalog()
+    register_telephony_status(catalog, TelephonyAccess(FakeBridge()))
+    result = catalog.invoke("get_phone_status", {})
+    assert result.is_error is False
+    body = json.loads(result.text)
+    assert body["carrierName"] == "AT&T"
+    assert body["voiceRegistered"] is True


### PR DESCRIPTION
## Summary

Proves and wires the native-to-agent telephony boundary for JackRabbit with a
read-only `get_phone_status` agent tool. No UI card, no call/SMS agent tools,
no new HTTP service — this slice de-risks the riskiest boundary before any
dialing/sending is exposed.

## Context

The Rabbit R1's base CipherOS image is a real LTE phone (MediaTek modem, MTK
RIL, AOSP Dialer + com.cipheros.messaging). With a carrier nano-SIM it
registers IN_SERVICE on LTE for VOICE, SMS, VIDEO, DATA/MMS. JackRabbit's own
app layer previously had zero telephony code or permissions.

## Architecture

Extends the existing single loopback API (Python at 127.0.0.1:8765) rather
than adding a new HTTP service. Native telephony is injected into the Python
runtime in-process, mirroring the existing `RuntimeCredentialBridge` precedent:

1. **`android/feature/telephony`** — `TelephonyBridge` interface +
   `AndroidTelephonyBridge` (TelephonyManager/SmsManager-backed). Primitive /
   String / boolean returns for Chaquopy robustness. Manifests the telephony
   permissions.
2. **runtime-host** builds the bridge in the `:runtime` process and passes it
   through `entrypoint.start(..., telephony_bridge)`, matching the existing
   `RuntimeCredentialBridge` injection pattern.
3. **Python runtime** wraps it in `TelephonyAccess` and registers a read-only
   `get_phone_status` MCP tool on the existing `ToolCatalog`. Absent-bridge
   returns a safe `enabled: false` snapshot; it never crashes the agent.

## Validation

- **Python (local, real):** new pytest harness under `runtime/`; 5 tests pass
  (TelephonyAccess facade, get_phone_status tool registration via
  `ToolCatalog.invoke`, and a smoke test). Import of `entrypoint` +
  `application` verified in the venv.
- **Android boundaries (local):** `android/scripts/check_boundaries.sh` passes
  (`standalone Android boundaries: OK`).
- **Android compile:** no local Android toolchain exists here, so the native
  module and runtime-host wiring compile verification is deferred to this PR's
  CI run.

## Acceptance criteria

- `feature/telephony` compiles and declares telephony permissions.
- `runtime-host` injects the bridge; startup succeeds with/without it.
- `get_phone_status` is registered on the `ToolCatalog`; returns a correct
  snapshot under a fake bridge, `enabled: false` when none is present.
- No new HTTP server, port, or listener is added.
- Python unit tests pass (5/5); `check_boundaries.sh` passes.

## Out of scope (future slices)

- Agent call/SMS tools with a bounded confirmation step before any outward
  action.
- Phone/SMS Card on the R1 deck.
- Incoming call/text event push to the agent.
- VoLTE / carrier data-provisioning validation on device.

Docs: this repo ignores `/docs/`, so the design and plan live outside the tree
(`~/projects/jackrabbitos/r1-telephony-bridge-{design,plan}.md`) and are not
committed.