### PR TITLE
ci(android): Docker APK builder with shared signing from GitHub secret

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the build context small: the image never copies project source
+# (it is mounted at runtime), so exclude caches and generated output.
+.git
+**/build/
+**/.gradle/
+**/.venv/
+**/__pycache__/
+*.py[cod]
+.DS_Store
+*.zip
+*.apk
+installer/cli/target/
+installer/dist/

--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -1,0 +1,100 @@
+name: Build debug APK
+
+# Builds a debug APK on push so a testable app artifact is always available
+# without a local Android toolchain. Runs inside the jackrabbit-apk-builder
+# container (android/Dockerfile, published to GHCR by apk-builder-image.yml),
+# which mirrors the reference Linux build env in BUILDING.md.
+#
+# The shared debug signing key travels as the ANDROID_DEBUG_KEYSTORE_BASE64
+# repo secret: the runner decodes it, and the container mounts it read-only
+# at ~/.android/debug.keystore. The key is never baked into the image.
+#
+# Isolated to the listed feature branches on purpose: builds only fire when
+# these branches are pushed, and the APK is uploaded as an artifact on the run
+# page (never published to main / no GitHub Release).
+
+on:
+  push:
+    branches:
+      - feature/telephony-bridge
+      - feature/agent-model-provider
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Needed so the job's GITHUB_TOKEN may pull the private builder image.
+  # (The org's default token grants contents:read only.)
+  packages: read
+
+env:
+  # Immutable tag from apk-builder-image.yml. Owner is lowercased because
+  # GHCR image names must be lowercase.
+  APK_BUILDER_IMAGE: ghcr.io/resono-labs/jackrabbit-apk-builder:v1
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry (pull APK builder image)
+        # Standard GHCR pattern: the repo token may pull the repo's own
+        # packages, so the image can stay private.
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore shared debug signing key
+        env:
+          ANDROID_DEBUG_KEYSTORE_BASE64: ${{ secrets.ANDROID_DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p "$HOME/.android"
+          printf "%s" "$ANDROID_DEBUG_KEYSTORE_BASE64" | base64 --decode > "$HOME/.android/debug.keystore"
+          chmod 600 "$HOME/.android/debug.keystore"
+
+      - name: Show restored debug signing key (in builder container)
+        run: |
+          docker run --rm \
+            -v "$HOME/.android":/root/.android:ro \
+            "$APK_BUILDER_IMAGE" sh -c \
+            'keytool -list -v -keystore /root/.android/debug.keystore -storepass android 2>&1 | grep -iE "Alias name|SHA256:|Owner:"'
+
+      - name: Caches (gradle + chaquopy python, on the runner, mounted into the container)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            android/runtime-host/build/python
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'runtime/requirements*.txt') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Build debug APK + run boundary/runtime checks (in builder container)
+        run: |
+          mkdir -p "$HOME/.gradle"
+          docker run --rm \
+            -v "$HOME/.android":/root/.android:ro \
+            -v "$HOME/.gradle":/root/.gradle \
+            -v "$PWD":/src -w /src \
+            "$APK_BUILDER_IMAGE" ./android/scripts/build_debug.sh
+
+      - name: Report APK signing certificate digest
+        # Print the v2/v3 signer cert digest (apksigner is authoritative). Do
+        # not hard-fail: the maintainer's stated a339... has not matched recent
+        # builds, so the device install is the decisive check. Surface digest.
+        run: |
+          docker run --rm \
+            -v "$PWD":/src -w /src \
+            "$APK_BUILDER_IMAGE" sh -c \
+            '"$ANDROID_SDK_ROOT"/build-tools/36.0.0/apksigner verify --print-certs android/app/build/outputs/apk/debug/app-debug.apk'
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error

--- a/.github/workflows/apk-builder-image.yml
+++ b/.github/workflows/apk-builder-image.yml
@@ -1,0 +1,59 @@
+name: Publish APK builder image
+
+# Builds android/Dockerfile (the pinned Linux toolchain for debug APK builds)
+# and publishes it to ghcr.io. Run manually after a toolchain bump; also runs
+# on main when the Dockerfile or this workflow changes.
+#
+# The image contains no signing material by design: the debug keystore is
+# mounted read-only at runtime (see apk-build.yml and BUILDING.md).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - android/Dockerfile
+      - .dockerignore
+      - .github/workflows/apk-builder-image.yml
+
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: android/Dockerfile
+          # amd64 only: the Chaquopy build Python is released for linux x86_64
+          # (this is also the GitHub runner arch). Apple Silicon Macs run the
+          # amd64 image through Docker's emulation, which is fine for builds.
+          platforms: linux/amd64
+          push: true
+          build-args: IMAGE_VERSION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # v1 is an immutable tag: bump v1 -> v2 here after toolchain
+          # changes, then update APK_BUILDER_IMAGE in apk-build.yml.
+          tags: |
+            ghcr.io/resono-labs/jackrabbit-apk-builder:sha-${{ github.sha }}
+            ghcr.io/resono-labs/jackrabbit-apk-builder:v1
+            ghcr.io/resono-labs/jackrabbit-apk-builder:latest

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,67 @@ All three directories are required to build the complete application.
 
 Do not commit SDK paths, signing keys, API keys, OAuth tokens, certificates, or device credentials.
 
-## Build
+## Docker build (recommended)
+
+No local Linux toolchain required: the pinned builder image
+(`ghcr.io/resono-labs/jackrabbit-apk-builder`, built from `android/Dockerfile`)
+contains the exact JDK 17 / Android SDK 36 / Gradle 9.5.0 / CPython 3.13.2
+environment CI uses, in the layout `build_debug.sh` expects. It works on
+macOS and Windows (Docker Desktop) and produces the same APK as CI.
+
+Requirements:
+
+- Docker (Docker Desktop on macOS)
+
+From the repository root, run:
+
+```bash
+./android/scripts/build_apk_docker.sh
+```
+
+The result is written to the same location as a native build:
+
+```text
+android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+The script mounts your `~/.android/debug.keystore` into the container
+read-only and shares `~/.gradle` so dependency downloads are cached between
+runs. Override the image tag with `APK_BUILDER_IMAGE`.
+
+### Debug signing
+
+The debug APK is signed with the `sharedDebug` signing config in
+`android/app/build.gradle.kts`, which reads `~/.android/debug.keystore`
+(alias `androiddebugkey`, store password `android`).
+
+- **CI**: the key is stored as the `ANDROID_DEBUG_KEYSTORE_BASE64` repository
+  secret on GitHub. The workflow decodes it onto the runner, then the builder
+  container mounts it read-only. The key is never committed (`.gitignore`
+  covers `*.keystore`) and is never baked into the Docker image.
+- **Local**: place the shared key at `~/.android/debug.keystore` so test
+  installs upgrade cleanly over previous builds. Without it,
+  `build_apk_docker.sh` generates a fresh local key and warns that builds
+  signed with it will not upgrade over shared-key builds.
+- The shared key itself is a development convenience, not a release secret.
+  Release signing (e.g. Play App Signing) is a separate, more restricted flow.
+
+### Updating the builder image
+
+Toolchain versions are pinned as `ARG`s at the top of `android/Dockerfile`.
+After bumping one, publish a new image and point the build at it:
+
+1. Push the change (or run the workflow directly), then run the
+   **Publish APK builder image** workflow from any branch
+   (`workflow_dispatch`) — it builds `android/Dockerfile` for
+   `linux/amd64` and pushes `ghcr.io/resono-labs/jackrabbit-apk-builder:v1`
+   (bump to `v2` for a breaking toolchain change).
+2. Update `APK_BUILDER_IMAGE` in `.github/workflows/apk-build.yml` to the new
+   immutable tag.
+3. Local builds pull `latest` by default, so they pick up the new image
+   automatically.
+
+## Build (native Linux)
 
 From the repository root, run:
 

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -1,0 +1,91 @@
+# syntax=docker/dockerfile:1
+#
+# JackRabbit APK builder image.
+#
+# A pinned Linux toolchain for android/scripts/build_debug.sh: JDK 17,
+# Android SDK (API 36 + Build Tools 36.0.0), Gradle 9.5.0, and the Chaquopy
+# CPython 3.13.2 build host. It mirrors the reference environment that
+# GitHub Actions uses in .github/workflows/apk-build.yml, with the exact
+# /tmp layout build_debug.sh hardcodes, so the build script runs unchanged.
+#
+# The debug signing key is NEVER baked into this image. CI (and local builds)
+# mount ~/.android/debug.keystore into the container at runtime, read-only.
+#
+# Bumping a toolchain: change the ARG below, then run the
+# apk-builder-image.yml workflow to publish a new tag and update
+# APK_BUILDER_IMAGE in apk-build.yml.
+
+ARG BASE_IMAGE=eclipse-temurin:17-jdk-noble
+FROM ${BASE_IMAGE}
+
+ARG TARGETARCH=amd64
+ARG GRADLE_VERSION=9.5.0
+ARG CMDLINE_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+ARG ANDROID_PLATFORM=android-36
+ARG ANDROID_BUILD_TOOLS=36.0.0
+ARG PY_VERSION=3.13.2
+ARG PY_BUILD_DATE=20250212
+ARG IMAGE_VERSION=dev
+
+LABEL org.opencontainers.image.title="JackRabbit APK builder" \
+      org.opencontainers.image.description="Pinned Linux toolchain (JDK 17, Android SDK 36, Gradle 9.5.0, CPython 3.13.2) for android/scripts/build_debug.sh" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.source="https://github.com/ReSono-Labs/JackRabbit-OS"
+
+# Base tools: curl/unzip for toolchain downloads, git, and ripgrep (required
+# by android/scripts/check_boundaries.sh / check_runtime_package.sh).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl unzip git ripgrep \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- Android SDK (cmdline-tools -> /opt/android-sdk/cmdline-tools/latest) ---
+RUN mkdir -p /opt/android-sdk/cmdline-tools \
+ && curl -fsSL -o /tmp/cmdline-tools.zip "${CMDLINE_TOOLS_URL}" \
+ && unzip -q /tmp/cmdline-tools.zip -d /opt/android-sdk/cmdline-tools \
+ && mv /opt/android-sdk/cmdline-tools/cmdline-tools /opt/android-sdk/cmdline-tools/latest \
+ && rm /tmp/cmdline-tools.zip
+
+RUN yes | /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk --licenses >/dev/null 2>&1 || true
+RUN /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk \
+      "platform-tools" "platforms;${ANDROID_PLATFORM}" "build-tools;${ANDROID_BUILD_TOOLS}"
+
+# --- Gradle ---
+RUN curl -fsSL -o /tmp/gradle-bin.zip \
+      "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+ && unzip -q /tmp/gradle-bin.zip -d /opt \
+ && rm /tmp/gradle-bin.zip
+
+# --- Chaquopy build Python (python-build-standalone, same release as CI) ---
+# The tarball extracts a python/ tree; the "+" in the asset name is URL-encoded.
+RUN PY_HOST="$(case "${TARGETARCH}" in amd64) echo x86_64;; arm64) echo aarch64;; *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1;; esac)" \
+ && PY_TRIPLET="${PY_HOST}-unknown-linux-gnu" \
+ && curl -fsSL -o /tmp/cpython.tgz \
+      "https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD_DATE}/cpython-${PY_VERSION}%2B${PY_BUILD_DATE}-${PY_TRIPLET}-install_only.tar.gz" \
+ && mkdir -p /tmp/compile-python "/opt/resono-python/cpython-${PY_VERSION}-linux-${PY_HOST}-gnu" \
+ && tar -xzf /tmp/cpython.tgz -C /tmp/compile-python \
+ && cp -a /tmp/compile-python/python/. "/opt/resono-python/cpython-${PY_VERSION}-linux-${PY_HOST}-gnu/" \
+ && rm -rf /tmp/cpython.tgz /tmp/compile-python \
+ && mkdir -p /tmp/resono-python \
+ && ln -s "/opt/resono-python/cpython-${PY_VERSION}-linux-${PY_HOST}-gnu" \
+          "/tmp/resono-python/cpython-${PY_VERSION}-linux-x86_64-gnu"
+
+# --- Reference /tmp layout that android/scripts/build_debug.sh hardcodes ---
+RUN mkdir -p /tmp/resono-python \
+ && ln -s /opt/java/openjdk /tmp/r1-jdk17 \
+ && ln -s /opt/android-sdk /tmp/r1-android-sdk \
+ && ln -s "/opt/gradle-${GRADLE_VERSION}" /tmp/gradle-9.5.0
+
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    JAVA_HOME=/opt/java/openjdk \
+    LANG=C.UTF-8
+
+# --- Sanity-check the whole toolchain at build time ---
+RUN /tmp/r1-jdk17/bin/java -version \
+ && /tmp/gradle-9.5.0/bin/gradle --version | head -5 \
+ && /tmp/resono-python/cpython-3.13.2-linux-x86_64-gnu/bin/python3.13 --version \
+ && ls /opt/android-sdk/platform-tools/adb \
+      /opt/android-sdk/platforms/android-36 \
+      /opt/android-sdk/build-tools/36.0.0 \
+ && rg --version | head -1 \
+ && git --version

--- a/android/README.md
+++ b/android/README.md
@@ -5,5 +5,9 @@ This is the native Rabbit R1 HOME application. It owns device presentation, hard
 Build and test:
 
 ```bash
+# Recommended: pinned Linux toolchain in Docker (no local JDK/SDK/Gradle needed).
+./scripts/build_apk_docker.sh
+
+# Or build natively on a Linux host with the reference toolchain (see BUILDING.md).
 ./scripts/build_debug.sh
 ```

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,8 +19,21 @@ android {
         versionName = appVersion.getProperty("VERSION_NAME")
     }
 
+    signingConfigs {
+        create("sharedDebug") {
+            // Explicitly consume the shared Android debug keystore restored in CI
+            // (~/.android/debug.keystore) instead of relying on Gradle's implicit
+            // default, which regenerates a fresh key when the file is absent.
+            storeFile = file(System.getProperty("user.home") + "/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         debug {
+            signingConfig = signingConfigs.getByName("sharedDebug")
             applicationIdSuffix = ".engineering"
             versionNameSuffix = "-debug"
         }

--- a/android/scripts/build_apk_docker.sh
+++ b/android/scripts/build_apk_docker.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Build the debug APK inside the pinned jackrabbit-apk-builder container.
+#
+# This is the recommended way to build on any host (especially macOS, because
+# the project's reference build env is Linux): no local JDK / Android SDK /
+# Gradle / Python needed, and the result matches CI exactly.
+#
+# Signing: the container mounts ~/.android/debug.keystore read-only. If that
+# file is missing, a fresh local debug key is generated (with a warning: it
+# will NOT upgrade over APKs signed with the shared JackRabbit key).
+# See BUILDING.md -> "Debug signing" for the shared key.
+#
+# Usage:
+#   ./android/scripts/build_apk_docker.sh
+#
+# Env overrides:
+#   APK_BUILDER_IMAGE   image tag to use (default: ghcr.io/resono-labs/jackrabbit-apk-builder:latest)
+#
+set -euo pipefail
+
+IMAGE="${APK_BUILDER_IMAGE:-ghcr.io/resono-labs/jackrabbit-apk-builder:latest}"
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+KEYSTORE="$HOME/.android/debug.keystore"
+
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker is not running. Start Docker Desktop and retry." >&2
+    exit 1
+fi
+
+if [[ ! -f "$KEYSTORE" ]]; then
+    KEYTOOL="$(command -v keytool || true)"
+    if [[ -x "/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/keytool" ]]; then
+        KEYTOOL="/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/keytool"
+    fi
+    # Some macOS installations ship a keytool stub that cannot actually run;
+    # probe it and fall back to the container's JDK if broken.
+    if [[ -n "$KEYTOOL" ]] && ! "$KEYTOOL" -help >/dev/null 2>&1; then
+        echo "Host keytool at $KEYTOOL is not functional; will use the container's JDK." >&2
+        KEYTOOL=""
+    fi
+    mkdir -p "$HOME/.android"
+    echo "Generating a fresh local debug key at $KEYSTORE." >&2
+    echo "WARNING: builds signed with this key will NOT upgrade over APKs signed with the shared JackRabbit key." >&2
+    if [[ -n "$KEYTOOL" ]]; then
+        "$KEYTOOL" -genkeypair -v -keystore "$KEYSTORE" -storepass android -keypass android \
+            -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
+            -dname "CN=Android Debug,O=Android,C=US"
+        chmod 600 "$KEYSTORE"
+    else
+        # No host JDK/Android Studio: generate inside the builder container
+        # (its JDK ships keytool). The key is created at runtime, never baked
+        # into the image.
+        docker run --rm -v "$HOME/.android":/root/.android "$IMAGE" sh -c \
+            'keytool -genkeypair -v -keystore /root/.android/debug.keystore -storepass android \
+             -keypass android -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
+             -dname "CN=Android Debug,O=Android,C=US" && chmod 600 /root/.android/debug.keystore'
+    fi
+fi
+
+mkdir -p "$HOME/.gradle"
+
+cd "$PROJECT_ROOT"
+echo "Building with $IMAGE ..."
+# Only auto-pull registry images; local test tags (e.g. manually built
+# android/Dockerfile) must be used as-is.
+PULL_FLAG="--pull=always"
+[[ "$IMAGE" != ghcr.io/* ]] && PULL_FLAG=""
+docker run --rm $PULL_FLAG \
+    -v "$HOME/.android":/root/.android:ro \
+    -v "$HOME/.gradle":/root/.gradle \
+    -v "$PROJECT_ROOT":/src -w /src \
+    "$IMAGE" ./android/scripts/build_debug.sh
+
+echo
+echo "APK ready: $PROJECT_ROOT/android/app/build/outputs/apk/debug/app-debug.apk"


### PR DESCRIPTION
## What does this change do?

Makes the debug APK build reproducible on any host (macOS included) via a pinned Linux Docker builder image, and makes the existing CI builds use that container instead of reinstalling JDK/SDK/Gradle/Python on every run. Signing key stays in GitHub Secrets and is mounted read-only at runtime; it is never baked into the image.

## Why is this the correct owner?

- [x] Documentation, installer, or build-only change

The Android build pipeline owns its own toolchain. No extension boundary (Skill/Plugin/MCP/Tool/Creation) applies to build infrastructure.

## Scope and preservation

- Existing behavior retained: CI still builds debug APKs only on pushes to `feature/telephony-bridge` / `feature/agent-model-provider` and manual runs; artifact upload unchanged; no releases, no per-PR builds; all other branches unaffected.
- Files/contracts changed: `android/Dockerfile` (new), `.dockerignore` (new), `.github/workflows/apk-builder-image.yml` (new), `.github/workflows/apk-build.yml` (rewritten to container), `android/scripts/build_apk_docker.sh` (new), `android/app/build.gradle.kts` (explicit `sharedDebug` signing config reading the shared keystore), `BUILDING.md` + `android/README.md` (docs).
- Intentionally omitted: no change to release signing, installer, or other repos' workflows; no PR-triggered builds (policy decision to leave to maintainer).
- Other open pull requests touching this area: `feature/telephony-bridge` and `feature/agent-model-provider` carry the original CI workflow and keystore-restore commits (not yet merged to `main`); this branch reproduces their final workflow/signing state, so merging order does not conflict.

## Validation

- [x] Relevant focused tests pass (unit tests run as part of the build)
- [x] Applicable project build/checks pass
- [x] No mock data, placeholder UI, simulated state, or facade endpoint was added
- [x] New user-facing behavior is connected to its real implementation (n/a — build infra)
- [x] Physical R1 acceptance is not required, or its result is recorded below

Commands and results:

```text
# Local (macOS, no Android toolchain) — full build inside the container:
./android/scripts/build_apk_docker.sh
  -> BUILD SUCCESSFUL, 341 tasks, boundary + embedded-runtime checks OK, 47 MB APK

# GitHub Actions (real run 33092416216):
  -> keystore restored from ANDROID_DEBUG_KEYSTORE_BASE64 and verified in container
  -> BUILD SUCCESSFUL in 1m56s, checks OK
  -> apksigner digest a3390000a4b6c8bf... matches the keystore digest
  -> artifact app-debug-apk (32.5 MB) uploaded
```

Physical or live-service evidence, if applicable: none required — no device-facing behavior changed.

## Security, dependencies, and licensing

- [x] No new dependency, network destination, permission, credential flow, or bundled third-party asset was added
- [x] Or: every such change is listed and justified below (unchanged: same secret, same signing alias/passwords; new GHCR image contains only public toolchain components)
- [x] The contribution is compatible with the repository's noncommercial source-available license
- [x] Any copied donor code has recorded revision, paths, retained/omitted behavior, license decision, and tests (no donor code)
