### PR TITLE
Codex/wifi captive portal sign in

### DIFF
--- a/android/app-version.properties
+++ b/android/app-version.properties
@@ -1,5 +1,5 @@
 # Canonical ReSono/JackRabbit Android product version.
 # VERSION_CODE must increase for every installable product build.
 # VERSION_NAME is the user-visible release identity shown in Settings > About.
-VERSION_CODE=32
-VERSION_NAME=0.4.26-Carrot1
+VERSION_CODE=33
+VERSION_NAME=0.4.27-Carrot1

--- a/android/app-version.properties
+++ b/android/app-version.properties
@@ -1,5 +1,5 @@
 # Canonical ReSono/JackRabbit Android product version.
 # VERSION_CODE must increase for every installable product build.
 # VERSION_NAME is the user-visible release identity shown in Settings > About.
-VERSION_CODE=33
-VERSION_NAME=0.4.27-Carrot1
+VERSION_CODE=34
+VERSION_NAME=0.4.28-Carrot1

--- a/android/app-version.properties
+++ b/android/app-version.properties
@@ -1,5 +1,5 @@
 # Canonical ReSono/JackRabbit Android product version.
 # VERSION_CODE must increase for every installable product build.
 # VERSION_NAME is the user-visible release identity shown in Settings > About.
-VERSION_CODE=34
-VERSION_NAME=0.4.28-Carrot1
+VERSION_CODE=35
+VERSION_NAME=0.4.29-Carrot1

--- a/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsInputPolicy.java
+++ b/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsInputPolicy.java
@@ -4,10 +4,60 @@ import com.resonolabs.ui.input.UiInputIntent;
 
 /** Input rules that keep the R1 wheel separate from device-setting mutations. */
 final class SettingsInputPolicy {
+    static final int NO_WIFI_ACTION_SELECTED = -1;
+
+    enum WifiAction { NONE, CONNECT_FIRST_NETWORK, OPEN_SIGN_IN, SCAN_AGAIN }
+
     private SettingsInputPolicy() { }
 
     static boolean consumeWheelWithoutAdjustment(String page, UiInputIntent intent) {
         if (intent != UiInputIntent.PREVIOUS && intent != UiInputIntent.NEXT) return false;
         return "Sound".equals(page) || "Display".equals(page);
+    }
+
+    static int wifiActionCount(boolean captivePortal) {
+        return captivePortal ? 2 : 1;
+    }
+
+    static WifiAction wifiActionAt(boolean captivePortal, int index) {
+        if (captivePortal) {
+            if (index == 0) return WifiAction.OPEN_SIGN_IN;
+            if (index == 1) return WifiAction.SCAN_AGAIN;
+        } else if (index == 0) {
+            return WifiAction.SCAN_AGAIN;
+        }
+        return WifiAction.NONE;
+    }
+
+    static int wifiSelectionAfterWheel(
+            boolean captivePortal, int selection, UiInputIntent intent) {
+        if (!captivePortal) return NO_WIFI_ACTION_SELECTED;
+        int lastAction = wifiActionCount(captivePortal) - 1;
+        if (intent == UiInputIntent.NEXT) {
+            return selection == NO_WIFI_ACTION_SELECTED ? 0 : Math.min(lastAction, selection + 1);
+        }
+        if (intent == UiInputIntent.PREVIOUS) {
+            return selection == NO_WIFI_ACTION_SELECTED ? lastAction : Math.max(0, selection - 1);
+        }
+        return selection;
+    }
+
+    static WifiAction wifiActivateAction(
+            boolean captivePortal, boolean hasNetworks, int selection) {
+        if (captivePortal && selection != NO_WIFI_ACTION_SELECTED) {
+            return wifiActionAt(true, selection);
+        }
+        if (hasNetworks) return WifiAction.CONNECT_FIRST_NETWORK;
+        return captivePortal ? WifiAction.OPEN_SIGN_IN : WifiAction.NONE;
+    }
+
+    static WifiAction wifiTouchAction(boolean captivePortal, float x, float y) {
+        if (!captivePortal) {
+            return y >= 520f && y <= 620f ? WifiAction.SCAN_AGAIN : WifiAction.NONE;
+        }
+        if (y < 532f || y > 604f) return WifiAction.NONE;
+        if (x >= 20f && x <= 232f) return WifiAction.OPEN_SIGN_IN;
+        if (x >= 248f && x <= 460f) return WifiAction.SCAN_AGAIN;
+        return WifiAction.NONE;
     }
 }

--- a/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
+++ b/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
@@ -211,7 +211,7 @@ public final class SettingsPanelView extends View implements UiInputTarget {
         if (!wifiActionStatus.isBlank()) {
             wifiHint = wifiActionStatus;
         } else if (wifiCaptivePortal) {
-            wifiHint = "Sign-in required";
+            wifiHint = "Sign in via system Wi-Fi";
         } else {
             wifiHint = wifiNetworks.isEmpty() ? wifiScanState : "Tap a network to connect";
         }
@@ -227,7 +227,7 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             String name = network.ssid().length() > 24 ? network.ssid().substring(0, 23) + "…" : network.ssid();
             ReSonoTheme.text(canvas, paint, name, 38f, top + 34f, 22f,
                     ReSonoTheme.INK, Paint.Align.LEFT, true);
-            String detail = network.connected() ? "CONNECTED" : (network.secured() ? "SECURE" : "OPEN");
+            String detail = wifiNetworkDetail(network.connected(), network.secured(), wifiCaptivePortal);
             ReSonoTheme.text(canvas, paint, detail, 425f, top + 32f, 14f,
                     network.connected() ? 0xff57d6a7 : ReSonoTheme.MUTED, Paint.Align.RIGHT, true);
             for (int bar = 0; bar < 4; bar++) {
@@ -238,11 +238,16 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             top += 59f;
         }
         if (wifiCaptivePortal) {
-            wifiActionButton(canvas, "OPEN SIGN-IN", 20f, 232f, wifiActionSelected == 0);
+            wifiActionButton(canvas, "WI-FI SETTINGS", 20f, 232f, wifiActionSelected == 0);
             wifiActionButton(canvas, "SCAN AGAIN", 248f, 460f, wifiActionSelected == 1);
         } else {
             button(canvas, "SCAN AGAIN", 20f, 532f, 460f);
         }
+    }
+
+    static String wifiNetworkDetail(boolean connected, boolean secured, boolean captivePortal) {
+        if (connected) return captivePortal ? "NEEDS SIGN-IN" : "CONNECTED";
+        return secured ? "SECURE" : "OPEN";
     }
 
     private void drawManagementPage(Canvas canvas) {

--- a/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
+++ b/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
+import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -63,10 +64,14 @@ public final class SettingsPanelView extends View implements UiInputTarget {
     private final ManagementOpenAiSource openAiSource;
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final WifiNetworkScanner wifiScanner;
+    private final WifiCaptivePortalMonitor wifiPortalMonitor;
     private int selected;
     private String openPage;
     private String wifiScanState = "Tap refresh to scan";
     private List<WifiNetworkScanner.Network> wifiNetworks = List.of();
+    private boolean wifiCaptivePortal;
+    private int wifiActionSelected = SettingsInputPolicy.NO_WIFI_ACTION_SELECTED;
+    private String wifiActionStatus = "";
     private String bluetoothStatus = "Ready";
     private ManagementPairingState managementState = ManagementPairingState.loading();
     private ManagementOpenAiState openAiState = ManagementOpenAiState.loading();
@@ -104,6 +109,14 @@ public final class SettingsPanelView extends View implements UiInputTarget {
         this.wifiScanner = new WifiNetworkScanner(activity, (state, networks) -> {
             wifiScanState = state;
             wifiNetworks = List.copyOf(networks);
+            invalidate();
+        });
+        this.wifiPortalMonitor = new WifiCaptivePortalMonitor(activity, active -> {
+            if (wifiCaptivePortal != active) {
+                wifiActionSelected = SettingsInputPolicy.NO_WIFI_ACTION_SELECTED;
+            }
+            wifiCaptivePortal = active;
+            if (!active) wifiActionStatus = "";
             invalidate();
         });
         setContentDescription("In-app device settings");
@@ -191,9 +204,17 @@ public final class SettingsPanelView extends View implements UiInputTarget {
 
     private void drawWifiPage(Canvas canvas) {
         SettingValue[] values = network();
-        ReSonoTheme.text(canvas, paint, values[0].value + "  •  " + values[1].value,
+        String internet = wifiCaptivePortal ? "Sign-in required" : values[1].value;
+        ReSonoTheme.text(canvas, paint, values[0].value + "  •  " + internet,
                 24f, 91f, 20f, ReSonoTheme.MUTED, Paint.Align.LEFT, true);
-        String wifiHint = wifiNetworks.isEmpty() ? wifiScanState : "TAP A NETWORK TO CONNECT";
+        String wifiHint;
+        if (!wifiActionStatus.isBlank()) {
+            wifiHint = wifiActionStatus;
+        } else if (wifiCaptivePortal) {
+            wifiHint = "Sign-in required";
+        } else {
+            wifiHint = wifiNetworks.isEmpty() ? wifiScanState : "Tap a network to connect";
+        }
         ReSonoTheme.text(canvas, paint, wifiHint.toUpperCase(), 24f, 127f, 17f,
                 ReSonoTheme.CYAN, Paint.Align.LEFT, true);
         float top = 148f;
@@ -216,7 +237,12 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             }
             top += 59f;
         }
-        button(canvas, "SCAN AGAIN", 20f, 532f, 460f);
+        if (wifiCaptivePortal) {
+            wifiActionButton(canvas, "OPEN SIGN-IN", 20f, 232f, wifiActionSelected == 0);
+            wifiActionButton(canvas, "SCAN AGAIN", 248f, 460f, wifiActionSelected == 1);
+        } else {
+            button(canvas, "SCAN AGAIN", 20f, 532f, 460f);
+        }
     }
 
     private void drawManagementPage(Canvas canvas) {
@@ -761,6 +787,15 @@ public final class SettingsPanelView extends View implements UiInputTarget {
                 ReSonoTheme.CYAN, Paint.Align.CENTER, true);
     }
 
+    private void wifiActionButton(
+            Canvas canvas, String label, float left, float right, boolean selected) {
+        button(canvas, label, left, 532f, right);
+        if (!selected) return;
+        paint.setColor(ReSonoTheme.VIOLET);
+        paint.setStyle(Paint.Style.FILL);
+        canvas.drawRoundRect(left, 546f, left + 5f, 590f, 3f, 3f, paint);
+    }
+
     private void adjustVolume(boolean increase) {
         AudioManager audio = activity.getSystemService(AudioManager.class);
         if (audio != null) audio.adjustStreamVolume(AudioManager.STREAM_MUSIC,
@@ -860,6 +895,32 @@ public final class SettingsPanelView extends View implements UiInputTarget {
         invalidate();
     }
 
+    private void performWifiAction(SettingsInputPolicy.WifiAction action) {
+        if (action == SettingsInputPolicy.WifiAction.CONNECT_FIRST_NETWORK) {
+            if (!wifiNetworks.isEmpty()) selectNetwork(wifiNetworks.get(0));
+        } else if (action == SettingsInputPolicy.WifiAction.OPEN_SIGN_IN) {
+            openWifiSignIn();
+        } else if (action == SettingsInputPolicy.WifiAction.SCAN_AGAIN) {
+            wifiActionStatus = "";
+            wifiScanner.refresh();
+        }
+    }
+
+    private void openWifiSignIn() {
+        if (!wifiCaptivePortal) return;
+        try {
+            activity.startActivity(new Intent(Settings.ACTION_WIFI_SETTINGS));
+            wifiActionStatus = "Opened system Wi-Fi settings";
+        } catch (ActivityNotFoundException missing) {
+            wifiActionStatus = "Wi-Fi settings unavailable";
+        } catch (SecurityException denied) {
+            wifiActionStatus = "System denied Wi-Fi settings";
+        } catch (RuntimeException failed) {
+            wifiActionStatus = "Could not open Wi-Fi settings";
+        }
+        invalidate();
+    }
+
     private static String quote(String value) { return '"' + value.replace("\"", "\\\"") + '"'; }
 
     @Override public boolean onTouchEvent(MotionEvent event) {
@@ -885,8 +946,16 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             float within = (y - networkTop) % 59f;
             if (y >= networkTop && row >= 0 && row < Math.min(6, wifiNetworks.size()) && within <= 52f) {
                 selectNetwork(wifiNetworks.get(row));
-            } else if (y >= 520f && y <= 620f) {
-                wifiScanner.refresh();
+            } else {
+                SettingsInputPolicy.WifiAction action = SettingsInputPolicy.wifiTouchAction(
+                        wifiCaptivePortal, x, y);
+                if (action != SettingsInputPolicy.WifiAction.NONE) {
+                    if (wifiCaptivePortal) {
+                        wifiActionSelected = action == SettingsInputPolicy.WifiAction.OPEN_SIGN_IN
+                                ? 0 : 1;
+                    }
+                    performWifiAction(action);
+                }
             }
         } else if ("AI".equals(openPage)) {
             boolean arrow = x >= 390f && x <= 460f;
@@ -936,8 +1005,16 @@ public final class SettingsPanelView extends View implements UiInputTarget {
         if (openPage == null && intent == UiInputIntent.ACTIVATE) {
             activateSelectedRow(); return true;
         }
+        if ("Wi-Fi".equals(openPage) && wifiCaptivePortal
+                && (intent == UiInputIntent.PREVIOUS || intent == UiInputIntent.NEXT)) {
+            wifiActionSelected = SettingsInputPolicy.wifiSelectionAfterWheel(
+                    true, wifiActionSelected, intent);
+            invalidate();
+            return true;
+        }
         if ("Wi-Fi".equals(openPage) && intent == UiInputIntent.ACTIVATE) {
-            if (!wifiNetworks.isEmpty()) selectNetwork(wifiNetworks.get(0));
+            performWifiAction(SettingsInputPolicy.wifiActivateAction(
+                    wifiCaptivePortal, !wifiNetworks.isEmpty(), wifiActionSelected));
             return true;
         }
         if (SettingsInputPolicy.consumeWheelWithoutAdjustment(openPage, intent)) {
@@ -971,7 +1048,10 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             return;
         }
         openPage = page;
-        if ("Wi-Fi".equals(openPage)) wifiScanner.refresh();
+        if ("Wi-Fi".equals(openPage)) {
+            wifiActionSelected = SettingsInputPolicy.NO_WIFI_ACTION_SELECTED;
+            wifiScanner.refresh();
+        }
         if ("Management".equals(openPage)) refreshManagement();
         if ("AI".equals(openPage)) refreshOpenAi();
         invalidate();
@@ -984,6 +1064,7 @@ public final class SettingsPanelView extends View implements UiInputTarget {
 
     @Override protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        wifiPortalMonitor.start();
         if (bluetoothReceiverRegistered) return;
         IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
         if (android.os.Build.VERSION.SDK_INT >= 33) {
@@ -996,6 +1077,7 @@ public final class SettingsPanelView extends View implements UiInputTarget {
 
     @Override protected void onDetachedFromWindow() {
         wifiScanner.close();
+        wifiPortalMonitor.close();
         if (bluetoothReceiverRegistered) {
             try { activity.unregisterReceiver(bluetoothReceiver); }
             catch (IllegalArgumentException ignored) { }

--- a/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
+++ b/android/feature/settings/src/main/java/com/resonolabs/feature/settings/SettingsPanelView.java
@@ -228,8 +228,11 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             ReSonoTheme.text(canvas, paint, name, 38f, top + 34f, 22f,
                     ReSonoTheme.INK, Paint.Align.LEFT, true);
             String detail = wifiNetworkDetail(network.connected(), network.secured(), wifiCaptivePortal);
+            int detailColor = wifiNeedsSignIn(network.connected(), wifiCaptivePortal)
+                    ? ReSonoTheme.AMBER
+                    : network.connected() ? 0xff57d6a7 : ReSonoTheme.MUTED;
             ReSonoTheme.text(canvas, paint, detail, 425f, top + 32f, 14f,
-                    network.connected() ? 0xff57d6a7 : ReSonoTheme.MUTED, Paint.Align.RIGHT, true);
+                    detailColor, Paint.Align.RIGHT, true);
             for (int bar = 0; bar < 4; bar++) {
                 paint.setColor(bar < network.signalLevel() ? ReSonoTheme.CYAN : 0xff3d3a4d);
                 canvas.drawRoundRect(432f + bar * 6f, top + 39f - bar * 4f,
@@ -238,7 +241,7 @@ public final class SettingsPanelView extends View implements UiInputTarget {
             top += 59f;
         }
         if (wifiCaptivePortal) {
-            wifiActionButton(canvas, "WI-FI SETTINGS", 20f, 232f, wifiActionSelected == 0);
+            wifiActionButton(canvas, "SIGN IN", 20f, 232f, wifiActionSelected == 0);
             wifiActionButton(canvas, "SCAN AGAIN", 248f, 460f, wifiActionSelected == 1);
         } else {
             button(canvas, "SCAN AGAIN", 20f, 532f, 460f);
@@ -246,8 +249,13 @@ public final class SettingsPanelView extends View implements UiInputTarget {
     }
 
     static String wifiNetworkDetail(boolean connected, boolean secured, boolean captivePortal) {
-        if (connected) return captivePortal ? "NEEDS SIGN-IN" : "CONNECTED";
+        if (wifiNeedsSignIn(connected, captivePortal)) return "NEEDS SIGN-IN";
+        if (connected) return "CONNECTED";
         return secured ? "SECURE" : "OPEN";
+    }
+
+    static boolean wifiNeedsSignIn(boolean connected, boolean captivePortal) {
+        return connected && captivePortal;
     }
 
     private void drawManagementPage(Canvas canvas) {

--- a/android/feature/settings/src/main/java/com/resonolabs/feature/settings/WifiCaptivePortalMonitor.java
+++ b/android/feature/settings/src/main/java/com/resonolabs/feature/settings/WifiCaptivePortalMonitor.java
@@ -1,0 +1,89 @@
+package com.resonolabs.feature.settings;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Observes confirmed captive-portal capability on Wi-Fi transports. */
+final class WifiCaptivePortalMonitor implements AutoCloseable {
+    interface Listener { void onCaptivePortalChanged(boolean active); }
+
+    private final ConnectivityManager connectivity;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final Listener listener;
+    private final Map<Network, Boolean> portalNetworks = new HashMap<>();
+    private boolean registered;
+    private boolean captivePortal;
+
+    private final ConnectivityManager.NetworkCallback callback =
+            new ConnectivityManager.NetworkCallback() {
+                @Override public void onCapabilitiesChanged(
+                        Network network, NetworkCapabilities capabilities) {
+                    update(network, capabilities);
+                }
+
+                @Override public void onLost(Network network) {
+                    if (!registered) return;
+                    portalNetworks.remove(network);
+                    publishIfChanged();
+                }
+            };
+
+    WifiCaptivePortalMonitor(Context context, Listener listener) {
+        this.connectivity = context.getSystemService(ConnectivityManager.class);
+        this.listener = listener;
+    }
+
+    void start() {
+        if (registered || connectivity == null) return;
+        NetworkRequest request = new NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build();
+        try {
+            connectivity.registerNetworkCallback(request, callback, mainHandler);
+            registered = true;
+        } catch (RuntimeException unavailable) {
+            registered = false;
+            portalNetworks.clear();
+            publish(false);
+        }
+    }
+
+    @Override public void close() {
+        if (registered) {
+            try {
+                connectivity.unregisterNetworkCallback(callback);
+            } catch (RuntimeException ignored) { }
+            registered = false;
+        }
+        portalNetworks.clear();
+        publish(false);
+    }
+
+    private void update(Network network, NetworkCapabilities capabilities) {
+        if (!registered) return;
+        boolean active = capabilities != null
+                && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_CAPTIVE_PORTAL);
+        portalNetworks.put(network, active);
+        publishIfChanged();
+    }
+
+    private void publishIfChanged() {
+        publish(portalNetworks.containsValue(true));
+    }
+
+    private void publish(boolean active) {
+        if (captivePortal == active) return;
+        captivePortal = active;
+        listener.onCaptivePortalChanged(active);
+    }
+}

--- a/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
+++ b/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
@@ -77,6 +77,13 @@ public final class SettingsInputPolicyTest {
         assertEquals("OPEN", SettingsPanelView.wifiNetworkDetail(false, false, true));
     }
 
+    @Test public void wifiSignInNeedsAttentionOnlyOnTheConnectedCaptiveNetwork() {
+        assertTrue(SettingsPanelView.wifiNeedsSignIn(true, true));
+        assertFalse(SettingsPanelView.wifiNeedsSignIn(true, false));
+        assertFalse(SettingsPanelView.wifiNeedsSignIn(false, true));
+        assertFalse(SettingsPanelView.wifiNeedsSignIn(false, false));
+    }
+
     @Test public void wifiHardwareIndexMapsToPortalActions() {
         assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
                 SettingsInputPolicy.wifiActionAt(false, 0));

--- a/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
+++ b/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
@@ -57,4 +57,94 @@ public final class SettingsInputPolicyTest {
         assertEquals("none", SettingsPanelView.nextOption("high", values));
         assertEquals("none", SettingsPanelView.nextOption("missing", values));
     }
+
+    @Test public void wifiActionCountOnlyAddsSignInForConfirmedPortal() {
+        assertEquals(1, SettingsInputPolicy.wifiActionCount(false));
+        assertEquals(2, SettingsInputPolicy.wifiActionCount(true));
+    }
+
+    @Test public void wifiHardwareIndexMapsToPortalActions() {
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiActionAt(false, 0));
+        assertEquals(SettingsInputPolicy.WifiAction.OPEN_SIGN_IN,
+                SettingsInputPolicy.wifiActionAt(true, 0));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiActionAt(true, 1));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiActionAt(true, 2));
+    }
+
+    @Test public void wifiWheelEntersAndMovesPortalActionSelection() {
+        assertEquals(0, SettingsInputPolicy.wifiSelectionAfterWheel(
+                true, SettingsInputPolicy.NO_WIFI_ACTION_SELECTED, UiInputIntent.NEXT));
+        assertEquals(1, SettingsInputPolicy.wifiSelectionAfterWheel(
+                true, SettingsInputPolicy.NO_WIFI_ACTION_SELECTED, UiInputIntent.PREVIOUS));
+        assertEquals(1, SettingsInputPolicy.wifiSelectionAfterWheel(
+                true, 0, UiInputIntent.NEXT));
+        assertEquals(0, SettingsInputPolicy.wifiSelectionAfterWheel(
+                true, 1, UiInputIntent.PREVIOUS));
+    }
+
+    @Test public void wifiWheelLeavesNonPortalHardwareBehaviorUntouched() {
+        assertEquals(SettingsInputPolicy.NO_WIFI_ACTION_SELECTED,
+                SettingsInputPolicy.wifiSelectionAfterWheel(
+                        false, 0, UiInputIntent.NEXT));
+        assertEquals(SettingsInputPolicy.NO_WIFI_ACTION_SELECTED,
+                SettingsInputPolicy.wifiSelectionAfterWheel(
+                        false, 0, UiInputIntent.PREVIOUS));
+    }
+
+    @Test public void wifiActivationPreservesFirstNetworkUntilPortalActionIsSelected() {
+        assertEquals(SettingsInputPolicy.WifiAction.CONNECT_FIRST_NETWORK,
+                SettingsInputPolicy.wifiActivateAction(false, true,
+                        SettingsInputPolicy.NO_WIFI_ACTION_SELECTED));
+        assertEquals(SettingsInputPolicy.WifiAction.CONNECT_FIRST_NETWORK,
+                SettingsInputPolicy.wifiActivateAction(true, true,
+                        SettingsInputPolicy.NO_WIFI_ACTION_SELECTED));
+        assertEquals(SettingsInputPolicy.WifiAction.OPEN_SIGN_IN,
+                SettingsInputPolicy.wifiActivateAction(true, false,
+                        SettingsInputPolicy.NO_WIFI_ACTION_SELECTED));
+        assertEquals(SettingsInputPolicy.WifiAction.OPEN_SIGN_IN,
+                SettingsInputPolicy.wifiActivateAction(true, true, 0));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiActivateAction(true, true, 1));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiActivateAction(false, false,
+                        SettingsInputPolicy.NO_WIFI_ACTION_SELECTED));
+    }
+
+    @Test public void wifiPortalTouchMatchesExactButtonBounds() {
+        assertEquals(SettingsInputPolicy.WifiAction.OPEN_SIGN_IN,
+                SettingsInputPolicy.wifiTouchAction(true, 20f, 532f));
+        assertEquals(SettingsInputPolicy.WifiAction.OPEN_SIGN_IN,
+                SettingsInputPolicy.wifiTouchAction(true, 232f, 604f));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiTouchAction(true, 248f, 532f));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiTouchAction(true, 460f, 604f));
+    }
+
+    @Test public void wifiPortalTouchRejectsGapAndOutsideEdges() {
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(true, 240f, 570f));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(true, 19f, 570f));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(true, 120f, 531f));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(true, 350f, 605f));
+    }
+
+    @Test public void wifiNonPortalTouchKeepsFullWidthScanButton() {
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiTouchAction(false, -100f, 520f));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiTouchAction(false, 240f, 570f));
+        assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
+                SettingsInputPolicy.wifiTouchAction(false, 580f, 620f));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(false, 240f, 519f));
+        assertEquals(SettingsInputPolicy.WifiAction.NONE,
+                SettingsInputPolicy.wifiTouchAction(false, 240f, 621f));
+    }
 }

--- a/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
+++ b/android/feature/settings/src/test/java/com/resonolabs/feature/settings/SettingsInputPolicyTest.java
@@ -63,6 +63,20 @@ public final class SettingsInputPolicyTest {
         assertEquals(2, SettingsInputPolicy.wifiActionCount(true));
     }
 
+    @Test public void wifiConnectedNetworkDetailDistinguishesSignInRequired() {
+        assertEquals("NEEDS SIGN-IN", SettingsPanelView.wifiNetworkDetail(true, false, true));
+        assertEquals("NEEDS SIGN-IN", SettingsPanelView.wifiNetworkDetail(true, true, true));
+        assertEquals("CONNECTED", SettingsPanelView.wifiNetworkDetail(true, false, false));
+        assertEquals("CONNECTED", SettingsPanelView.wifiNetworkDetail(true, true, false));
+    }
+
+    @Test public void wifiDisconnectedNetworkDetailPreservesSecurityLabels() {
+        assertEquals("SECURE", SettingsPanelView.wifiNetworkDetail(false, true, false));
+        assertEquals("SECURE", SettingsPanelView.wifiNetworkDetail(false, true, true));
+        assertEquals("OPEN", SettingsPanelView.wifiNetworkDetail(false, false, false));
+        assertEquals("OPEN", SettingsPanelView.wifiNetworkDetail(false, false, true));
+    }
+
     @Test public void wifiHardwareIndexMapsToPortalActions() {
         assertEquals(SettingsInputPolicy.WifiAction.SCAN_AGAIN,
                 SettingsInputPolicy.wifiActionAt(false, 0));


### PR DESCRIPTION
## What does this change do?

Adds a clear sign-in path for Wi-Fi networks requiring captive-portal authentication. These networks now show an amber `NEEDS SIGN-IN` status and a compact `SIGN IN` action that opens Android’s Wi-Fi settings to continue authentication.

Key implementation decisions:

- Require explicit `CAPTIVE_PORTAL` capability; missing internet validation alone does not imply a portal.
- Delegate authentication to Android’s system UI, without an embedded WebView or automatic popup.

## Why is this the correct owner?

- [x] Native Android feature

The existing `android/feature/settings` module owns Wi-Fi state, native settings UI, and hardware input. This change stays within that boundary.

I reviewed the [[Extension Development Guide](https://github.com/ReSono-Labs/JackRabbit-OS/blob/main/EXTENSION-DEVELOPMENT.md)](https://github.com/ReSono-Labs/JackRabbit-OS/blob/main/EXTENSION-DEVELOPMENT.md) and confirmed this change does not duplicate an existing owner.

## Scope and preservation

- **Existing behavior retained:** Wi-Fi scanning, connection handling, and non-portal interactions.
- **Files/contracts changed:** New `WifiCaptivePortalMonitor`; updated `SettingsPanelView`, `SettingsInputPolicy`, focused tests, and app version.
- **Intentionally omitted:** Automatic portal launch, embedded authentication, custom connectivity probes, and lock-screen changes.
- **Other open pull requests touching this area:** None found at review time.

## Validation

- [x] Relevant focused tests pass
- [x] Applicable project build/checks pass
- [x] No mock data, placeholder UI, simulated state, or facade endpoint was added
- [x] New user-facing behavior is connected to its real implementation
- [x] Physical R1 acceptance result is recorded below

Commands and results:

```text
./android/scripts/build_debug.sh
PASS — build, Android boundaries, embedded runtime checks

gradle --no-daemon --no-configuration-cache testDebugUnitTest --rerun
PASS — 28 tests, including 18 settings tests
```

[[Signed debug APK CI build passed](https://github.com/ReSono-Labs/JackRabbit-OS/actions/runs/33716077806)](https://github.com/ReSono-Labs/JackRabbit-OS/actions/runs/33716077806).

**Physical R1 evidence:** Captive-portal detection and system Wi-Fi handoff were tested on hardware. The installed v35 build also confirms the amber status and shortened button layout.

**Known system limitation:** The first settings handoff may be covered by Keyguard. Existing lock-screen behavior is unchanged and out of scope.

## Security, dependencies, and licensing

- [x] No new dependency, network destination, permission, app-owned credential flow, or bundled third-party asset was added.
- [x] The contribution is compatible with the repository’s noncommercial source-available license.

Authentication remains in Android’s system UI; the app does not collect or store portal credentials. No donor code was copied, so donor provenance requirements are not applicable.